### PR TITLE
Iterate over correct response variable in getProviderVDCId

### DIFF
--- a/src/core/vcd/vcdValidations.py
+++ b/src/core/vcd/vcdValidations.py
@@ -1028,9 +1028,9 @@ class VCDMigrationValidation:
                     raise Exception("Failed to get Provider VDC details : {}".format(errorDict['message']))
 
             # iterating over all provider vdcs to find if the specified provider vdc details exists
-            for response in responseDict['values']:
+            for response in resultList:
                 if returnRaw:
-                    return responseDict['values']
+                    return resultList
                 if response['name'] == pvdcName:
                     logger.debug("Retrieved Provider VDC {} id successfully".format(pvdcName))
                     # returning provider vdc id of specified pvdcName & nsx-t manager


### PR DESCRIPTION
In the getProviderVDCId function, the iteration over all provider vdcs was referencing responseDict['values'] which only refers to the final iteration of the paginated response. This variable should actually be resultList, which the responseDict['values'] are appended to on each loop over the paginated results. 

The current state limits the tool to only working with 25 or less Provider VDCs. 